### PR TITLE
Added missing header comment metadata

### DIFF
--- a/mainwp-key-maker.php
+++ b/mainwp-key-maker.php
@@ -6,6 +6,10 @@
 	Author: MainWP
 	Author URI: https://mainwp.com
 	Version: 1.1
+	Requires at least: 3.6
+	Text Domain: mainwp-key-maker
+	License: GPL v2 or later
+	License URI: https://www.gnu.org/licenses/gpl-2.0.html
  */
 
 // If we made redirection in this session

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Author: mainwp
 Author URI: https://mainwp.com
 Plugin URI: https://mainwp.com
 Requires at least: 3.6
-Tested up to: 4.9
+Tested up to: 5.4
 Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
*mainwp-key-maker.php*
- Added the same "Requires at least" of MainWP Dashboard.
- Because "Requires at least" is below 4.6. we need to set a Text Domain in mainwp-key-maker.php and it needs to be mainwp-key-maker to correctly internationalize the plugin. (More info: https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains)
- Setting a License header is mandatory for new plugins since April 2020. Consider adding one, preferably the same one as WordPress itself: “GPLv2 or later” (More info: https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#1-plugins-must-be-compatible-with-the-gnu-general-public-license)

*readme.txt*
- Added "Tested up to: 5.4". We can limit the "Tested up to:" to just the major release (e.g. 5.4). The repository will automatically add the latest minor version as plugins shouldn’t break with a minor update.